### PR TITLE
Add basic rules for Backing CHN

### DIFF
--- a/Rulesets/App/storage/Baiduyun.list
+++ b/Rulesets/App/storage/Baiduyun.list
@@ -1,2 +1,2 @@
 # 百度云
-PROCESS-NAME,BaiduNetdisk_mac,DIRECT
+PROCESS-NAME,BaiduNetdisk_mac

--- a/Rulesets/App/storage/Baiduyun.list
+++ b/Rulesets/App/storage/Baiduyun.list
@@ -1,0 +1,2 @@
+# 百度云
+PROCESS-NAME,BaiduNetdisk_mac,DIRECT

--- a/Rulesets/App/stream/Iqiyi-cdn.list
+++ b/Rulesets/App/stream/Iqiyi-cdn.list
@@ -1,0 +1,1 @@
+DOMAIN-SUFFIX,iqiyipic.com

--- a/Rulesets/App/stream/Iqiyi.list
+++ b/Rulesets/App/stream/Iqiyi.list
@@ -1,5 +1,4 @@
 # IQIYI
-#PROCESS-NAME,爱奇艺,CHINA,force-remote-dns,enhanced-mode
-DOMAIN-SUFFIX,iqiyipic.com,DIRECT
-DOMAIN-KEYWORD,qiyi,CHINA,force-remote-dns,enhanced-mode
-DOMAIN-SUFFIX,qy.net,CHINA,force-remote-dns,enhanced-mode
+#PROCESS-NAME,爱奇艺,force-remote-dns,enhanced-mode
+DOMAIN-KEYWORD,qiyi,force-remote-dns,enhanced-mode
+DOMAIN-SUFFIX,qy.net,force-remote-dns,enhanced-mode

--- a/Rulesets/App/stream/Iqiyi.list
+++ b/Rulesets/App/stream/Iqiyi.list
@@ -1,0 +1,5 @@
+# IQIYI
+#PROCESS-NAME,爱奇艺,CHINA,force-remote-dns,enhanced-mode
+DOMAIN-SUFFIX,iqiyipic.com,DIRECT
+DOMAIN-KEYWORD,qiyi,CHINA,force-remote-dns,enhanced-mode
+DOMAIN-SUFFIX,qy.net,CHINA,force-remote-dns,enhanced-mode

--- a/Rulesets/App/tools/Thunder.list
+++ b/Rulesets/App/tools/Thunder.list
@@ -1,2 +1,2 @@
-DOMAIN-SUFFIX,idx.m.hub.sandai.net,CHINA,force-remote-dns,enhanced-mode
-DOMAIN-SUFFIX,hub5emu.sandai.net,CHINA,force-remote-dns,enhanced-mode
+DOMAIN-SUFFIX,idx.m.hub.sandai.net,force-remote-dns,enhanced-mode
+DOMAIN-SUFFIX,hub5emu.sandai.net,force-remote-dns,enhanced-mode

--- a/Rulesets/App/tools/Thunder.list
+++ b/Rulesets/App/tools/Thunder.list
@@ -1,0 +1,2 @@
+DOMAIN-SUFFIX,idx.m.hub.sandai.net,CHINA,force-remote-dns,enhanced-mode
+DOMAIN-SUFFIX,hub5emu.sandai.net,CHINA,force-remote-dns,enhanced-mode

--- a/Rulesets/Apple/Apple-direct-estero.list
+++ b/Rulesets/Apple/Apple-direct-estero.list
@@ -1,0 +1,32 @@
+PROCESS-NAME,storedownloadd,DIRECT // Mac App Store
+
+USER-AGENT,%E5%9C%B0%E5%9B%BE*,DIRECT // Maps
+USER-AGENT,%E8%AE%BE%E7%BD%AE*,DIRECT // Settings
+USER-AGENT,*com.apple.mobileme.fmip1,DIRECT
+USER-AGENT,*WeatherFoundation*,DIRECT
+USER-AGENT,AssistantServices*,DIRECT //Siri
+USER-AGENT,MobileAsset*,DIRECT
+USER-AGENT,Siri*,DIRECT
+
+USER-AGENT,cloudd*,DIRECT //iCloud
+USER-AGENT,com.apple.appstored*,DIRECT // iOS App Store
+USER-AGENT,com.apple.geod*,DIRECT
+USER-AGENT,com.apple.Maps,DIRECT
+USER-AGENT,FindMyFriends*,DIRECT
+USER-AGENT,FindMyiPhone*,DIRECT
+USER-AGENT,FMDClient*,DIRECT
+USER-AGENT,FMFD*,DIRECT
+USER-AGENT,fmflocatord*,DIRECT
+USER-AGENT,geod*,DIRECT
+USER-AGENT,locationd*,DIRECT
+USER-AGENT,Maps*,DIRECT
+
+DOMAIN-SUFFIX,aaplimg.com,DIRECT
+DOMAIN-SUFFIX,apple.co,DIRECT
+DOMAIN-SUFFIX,apple.com,DIRECT
+DOMAIN-SUFFIX,icloud.com,DIRECT
+DOMAIN-SUFFIX,icloud-content.com,DIRECT
+DOMAIN-SUFFIX,itunes.com,DIRECT
+DOMAIN-SUFFIX,me.com,DIRECT
+DOMAIN-SUFFIX,mzstatic.com,DIRECT // App Store & iTunes Images
+DOMAIN-SUFFIX,push-apple.com.akadns.net,DIRECT

--- a/Rulesets/Custom/website-acceleration.list
+++ b/Rulesets/Custom/website-acceleration.list
@@ -1,6 +1,6 @@
 ## QQ-MAIL
-DOMAIN-SUFFIX,qqmail.com,ASIA,force-remote-dns
-DOMAIN-SUFFIX,mail.qq.com,ASIA,force-remote-dns
+DOMAIN-SUFFIX,qqmail.com,force-remote-dns
+DOMAIN-SUFFIX,mail.qq.com,force-remote-dns
 
 ## ZIMUXIA
-DOMAIN-SUFFIX,zimuxia.cn,ASIA,force-remote-dns
+DOMAIN-SUFFIX,zimuxia.cn,force-remote-dns

--- a/Rulesets/Custom/website-acceleration.list
+++ b/Rulesets/Custom/website-acceleration.list
@@ -1,0 +1,6 @@
+## QQ-MAIL
+DOMAIN-SUFFIX,qqmail.com,ASIA,force-remote-dns
+DOMAIN-SUFFIX,mail.qq.com,ASIA,force-remote-dns
+
+## ZIMUXIA
+DOMAIN-SUFFIX,zimuxia.cn,ASIA,force-remote-dns


### PR DESCRIPTION
- [x]  迅雷 Thunder - ED2K/eMule 服务
- [x]  [QQ Mail](https://mail.qq.com)
- [x]  [字幕侠](http://www.zimuxia.cn)
- [x]  Apple DIRECT
- [x]  百度云盘 for macOS
- [x]  爱奇艺
- [x]  爱奇艺 CDN

For some of the website, Asian IPs are allowed such as QQ Mail, zimuxia.cn.

However, the rules are strict for those cases like streaming APPs because of the `GEOIP` authentication.

So users should separate the groups of the servers from ASIA and CHINA clearly for lower latency and better UE.